### PR TITLE
Documentation fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ $tax = $this->IncomeTax->calculateTax(
     new DateTime('2018-06-02'),   // The payment date
     [
         'type' => 'standard',     // The type of taxation - either `standard`, `help`, `sfss`, `combo` or `seniors`
-        'scale' => '1'            // The taxation scale
+        'scale' => '1'            // The taxation scale - `1` (tax free threshold not claimed), `2` (tax free threshold claimed), `3` (foreign resident), `4` (no TFN), `5` (full medicare exemption), `5` (half medicare exemption) 
     ]
 );
 ```

--- a/README.md
+++ b/README.md
@@ -63,13 +63,11 @@ Once loaded, you can calculate the tax withheld amount of a wage using the follo
 
 ```php
 $tax = $this->IncomeTax->calculateTax(
-    1000,                         // The gross wage
-    'weekly',                     // The pay cycle - must be either `weekly`, `fortnightly`, `monthly` or `quarterly`
-    new DateTime('2018-06-02'),   // The payment date
-    [
-        'type' => 'standard',     // The type of taxation - either `standard`, `help`, `sfss`, `combo` or `seniors`
-        'scale' => '1'            // The taxation scale - `1` (tax free threshold not claimed), `2` (tax free threshold claimed), `3` (foreign resident), `4` (no TFN), `5` (full medicare exemption), `5` (half medicare exemption) 
-    ]
+    1000,           // The gross wage
+    'weekly',       // The pay cycle - must be either `weekly`, `fortnightly`, `monthly` or `quarterly`
+    '2018-06-02',   // The payment date
+    'standard',     // The type of taxation - either `standard`, `help`, `sfss`, `combo` or `seniors`
+     2              // The taxation scale - `1` (tax free threshold not claimed), `2` (tax free threshold claimed), `3` (foreign resident), `4` (no TFN), `5` (full medicare exemption), `5` (half medicare exemption) 
 );
 ```
 

--- a/tests/TestCase/WeeklyTest.php
+++ b/tests/TestCase/WeeklyTest.php
@@ -92,7 +92,7 @@ class WeeklyTest extends TestCase
     }
 
     /**
-     * Test Scale 2 withheld amounts - Where Tax Free Threshold is not claimed
+     * Test Scale 2 withheld amounts - Where Tax Free Threshold is claimed
      *
      * Values taken from ATO's "Statement of formulas for calculating amounts to be withheld 2018-19" PDF
      * https://www.ato.gov.au/uploadedFiles/Content/MEI/downloads/Calculating-amounts-to-be-withheld-2018-19.pdf


### PR DESCRIPTION
A couple of documentation fixes. 

1. Documented available scales (derived from test case)
1. Updated usage arguments which didn't seem to align with `calculateTax` 
1. Updated test docblock for tax free threshold.